### PR TITLE
Perceptible table cells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 client_secrets.json
 tokens.yaml
 .byebug_history
+.DS_Store

--- a/lib/metadocs/elements/metadata_table.rb
+++ b/lib/metadocs/elements/metadata_table.rb
@@ -73,7 +73,7 @@ module Metadocs
         return nil
       end
 
-      if tuple? && perceptible_cells.length < 2
+      if tuple? && rows.length < 2
         @error = 'Tuple-type tables must have at least 2 rows'
         return nil
       end

--- a/lib/metadocs/elements/metadata_table.rb
+++ b/lib/metadocs/elements/metadata_table.rb
@@ -49,6 +49,10 @@ module Metadocs
       rows[1].cells
     end
 
+    def perceptible_header_cells
+      rows[1].perceptible_cells
+    end
+
     protected
 
     def parse_metadata
@@ -69,7 +73,7 @@ module Metadocs
         return nil
       end
 
-      if tuple? && rows.length < 2
+      if tuple? && perceptible_cells.length < 2
         @error = 'Tuple-type tables must have at least 2 rows'
         return nil
       end
@@ -88,13 +92,13 @@ module Metadocs
       data = {}
       data_rows = rows[1..]
 
-      unless data_rows.all? { |r| r.cells.length == 2 }
+      unless data_rows.all? { |r| r.perceptible_cells.length == 2 }
         @error = 'Data rows must have 2 cells'
         return nil
       end
 
       data_rows.each do |row|
-        key_cell, value_cell = row.cells
+        key_cell, value_cell = row.perceptible_cells
 
         unless all_text?(key_cell)
           @error = 'Key cells must only have text elements'
@@ -114,13 +118,13 @@ module Metadocs
       data = []
       data_rows = rows[2..]
 
-      headers = header_cells.map { |c| join_text(c).downcase }
+      headers = perceptible_header_cells.map { |c| join_text(c).downcase }
       if headers.any?(&:empty?)
         @error = 'Headers must not be empty'
         return nil
       end
 
-      unless data_rows.all? { |r| r.cells.length == header_cells.length }
+      unless data_rows.all? { |r| r.perceptible_cells.length == perceptible_header_cells.length }
         @error = 'All data rows must have the same number of cells as the header row'
         return nil
       end
@@ -128,7 +132,7 @@ module Metadocs
       data_rows.each do |row|
         entry = {}
         headers.each_with_index do |header, idx|
-          entry[header] = Elements::Body.with_renderers(renderers, children: row.cells[idx].children.dup)
+          entry[header] = Elements::Body.with_renderers(renderers, children: row.perceptible_cells[idx].children.dup)
         end
 
         next if entry.values.all? { |c| all_text?(c) && join_text(c).empty? }

--- a/lib/metadocs/elements/table_cell.rb
+++ b/lib/metadocs/elements/table_cell.rb
@@ -6,12 +6,15 @@ module Metadocs
   module Elements
     class TableCell < Elements::Element
       has_children
+      attr_accessor :column_span, :row_span
 
-      def initialize(children: [])
+      def initialize(column_span: nil, row_span: nil, children: [])
         super()
         raise ArgumentError, 'Children must be an array' unless children.is_a?(Array)
 
         @children = children
+        @column_span = column_span
+        @row_span = row_span
       end
     end
   end

--- a/lib/metadocs/elements/table_row.rb
+++ b/lib/metadocs/elements/table_row.rb
@@ -13,6 +13,17 @@ module Metadocs
         super()
         self.cells = cells
       end
+
+      def perceptible_cells
+        p_cells = []
+        i = 0
+        while i < cells.count
+          cell = cells[i]
+          p_cells << cell
+          i += cell.column_span
+        end
+        p_cells
+      end
     end
   end
 end

--- a/lib/metadocs/parser.rb
+++ b/lib/metadocs/parser.rb
@@ -229,10 +229,14 @@ module Metadocs
         row = Elements::TableRow.with_renderers(renderers)
         table.rows << row
         cell_ids.each do |cell_id|
-          cell = Elements::TableCell.with_renderers(renderers)
+          cell_mapping = source_map[cell_id]
+          cell = Elements::TableCell.with_renderers(
+            renderers,
+            column_span: cell_mapping['element'].table_cell_style.column_span,
+            row_span: cell_mapping['element'].table_cell_style.row_span,
+          )
           row.cells << cell
 
-          cell_mapping = source_map[cell_id]
           cell_bbdocs = Metadocs::Bbdocs.new(
             tags: tag_names,
             empty_tags: empty_tag_names,


### PR DESCRIPTION
From an editor perspective, a data table with merged cells is identical to a data table without merged cells. Since the intent of this library is to handle editor-created data, we should perceive data tables the way an editor does.